### PR TITLE
Add configure check X_AC_FLUX

### DIFF
--- a/config/x_ac_flux.m4
+++ b/config/x_ac_flux.m4
@@ -1,0 +1,84 @@
+##*****************************************************************************
+#  SYNOPSIS:
+#    X_AC_FLUX()
+#
+#  DESCRIPTION:
+#    Check the usual suspects for a FLUX installation,
+#    updating CPPFLAGS and LDFLAGS as necessary.
+#
+#  WARNINGS:
+#    This macro must be placed after AC_PROG_CC and before AC_PROG_LIBTOOL.
+##*****************************************************************************
+
+# --with-flux=no	no test for flux
+# --with-flux=check	look in default location
+# --with-flux		look in default location; error on fail
+# --with-flux=yes	look in default location; error on fail
+# --with-flux=<path>	look under <path>; error on fail
+
+AC_DEFUN([X_AC_FLUX], [
+  AC_ARG_WITH(
+    [flux],
+    AS_HELP_STRING(--with-flux=PATH,Specify path to flux installation),
+    [],
+    [with_flux=check])
+
+  AS_IF([test x$with_flux != xno],[
+    flux_extra_libs=""
+    found_flux=no
+
+    # Check for FLUX library in the default location.
+    AS_IF([test x$with_flux = xyes -o x$with_flux = xcheck],[
+      AC_SEARCH_LIBS([flux_open], [flux-core], [found_flux=yes], [found_flux=no], [$flux_extra_libs])
+    ])
+
+    AS_IF([test x$found_flux = xno -a x$with_flux != xyes -a x$with_flux != xcheck ],[
+      AC_CACHE_CHECK([for FLUX include directory],
+                     [x_ac_cv_flux_includedir],
+                     [FLUX_INCLUDEDIR="$with_flux/include/"
+                      AS_IF([test -f "$FLUX_INCLUDEDIR/flux/core.h"],
+                            [x_ac_cv_flux_includedir="$FLUX_INCLUDEDIR"],
+                            [x_ac_cv_flux_includedir=no])
+                     ])
+      AC_CACHE_CHECK([for FLUX library directory],
+                     [x_ac_cv_flux_libdir],
+                     [x_ac_cv_flux_libdir=no
+                      _x_ac_flux_libs_save=$LIBS
+                      FLUX_LIBDIR="$with_flux/lib/"
+                      AS_IF([test -d "$FLUX_LIBDIR"],[
+                        LIBS="-L$FLUX_LIBDIR -lflux-core $flux_extra_libs $LIBS"
+                        CFLAGS="-I $x_ac_cv_flux_includedir"
+                        AC_LINK_IFELSE(
+                          [AC_LANG_PROGRAM([#include <flux/core.h>], [flux_open(NULL,0);])],
+                          [x_ac_cv_flux_libdir=$FLUX_LIBDIR]
+                        )
+                      ])
+                      LIBS="$_x_ac_flux_libs_save"
+                     ])
+      AS_IF([test x$x_ac_cv_flux_includedir != xno -a x$x_ac_cv_flux_libdir != xno],[
+             found_flux=yes
+             FLUX_CPPFLAGS="-I$FLUX_INCLUDEDIR"
+             FLUX_LDFLAGS="-L$FLUX_LIBDIR"
+            ],[
+             found_flux=no
+             FLUX_CPPFLAGS=""
+             FLUX_LDFLAGS=""
+            ])
+    ])
+
+    AS_IF([test x$found_flux != xyes],[
+      AS_IF([test x$with_flux != xcheck],
+        [AC_MSG_ERROR([FLUX not found!])],
+        [AC_MSG_WARN([not building support for FLUX])])
+    ], [
+        FLUX_LIBADD="-lflux-core $flux_extra_libs"
+        AC_SUBST(FLUX_LIBADD)
+        AC_SUBST(FLUX_CPPFLAGS)
+        AC_SUBST(FLUX_LDFLAGS)
+        AC_DEFINE([HAVE_LIBFLUX], 1, [Define to 1 if you have the `flux-core' library (-lflux-core).])
+    ])
+  ])
+
+
+  AM_CONDITIONAL(WITH_FLUX, test "x$found_flux" = xyes)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ X_AC_SLURM
 X_AC_LCRM
 X_AC_MOAB
 X_AC_LSF
+X_AC_FLUX
 
 aix_64bit_mode=no
 using_aix=no


### PR DESCRIPTION
Based on X_AC_LSF.

Use flux_open() function provided by flux-core.so to determine whether
flux is installed.

Getting actual remaining time in an allocation depends on getting a json
description of the allocation using functions in flux-core.so, and
extracting the remaining time using jansson.so.  This will be in a
separate commit.