### PR TITLE
update for flux-core changes in 0.46 and 0.47

### DIFF
--- a/config/x_ac_flux_job_timeleft.m4
+++ b/config/x_ac_flux_job_timeleft.m4
@@ -1,0 +1,30 @@
+##*****************************************************************************
+#  SYNOPSIS:
+#    X_AC_FLUX_JOB_TIMELEFT()
+#
+#  DESCRIPTION:
+#    Check flux_job_timeleft() is present
+##*****************************************************************************
+
+AC_DEFUN([X_AC_FLUX_JOB_TIMELEFT], [
+  AS_IF([test "$FLUX_LIBADD"],[
+    AC_MSG_CHECKING([Whether flux_job_timeleft() is present.])
+    LIBS="$FLUX_LIBS $FLUX_LIBADD $LIBS"
+    AC_LINK_IFELSE([
+      AC_LANG_PROGRAM(
+        [[#include <flux/core.h>]],
+        [[double tl = flux_job_timeleft(NULL, NULL, NULL);]]
+      )],
+      [x_ac_cv_flux_job_timeleft=1],
+      [x_ac_cv_flux_job_timeleft=0]
+    )
+    AS_IF([test "x$x_ac_cv_flux_job_timeleft" = x1],
+      [AC_MSG_RESULT([yes])],
+      [
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([flux_job_timeleft() is required.  Update to a newer flux or use --without-flux.])
+      ]
+    )
+  ])
+
+])

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ X_AC_LCRM
 X_AC_MOAB
 X_AC_LSF
 X_AC_FLUX
+X_AC_FLUX_JOB_TIMELEFT
 
 aix_64bit_mode=no
 using_aix=no

--- a/libyogrt.spec.in
+++ b/libyogrt.spec.in
@@ -85,7 +85,7 @@ SLURM plugin for libyogrt
 %package flux
 Summary: libyogrt plugin for Flux
 Group: System Environment/Base
-BuildRequires: flux-core
+BuildRequires: flux-core >= 0.47.0
 Requires: flux-core
 Requires: libyogrt = %{version}
 %description flux

--- a/src/flux/internal.c
+++ b/src/flux/internal.c
@@ -62,6 +62,9 @@ int internal_init(int verb)
 				  " Remaining time will be a bogus value.\n");
 			goto out;
 		}
+		debug("flux_attr_get returned jobid_str=%s\n", jobid_str);
+	} else {
+		debug("Environment contains FLUX_JOB_ID=%s\n", jobid_str);
 	}
 
 	if (flux_job_id_parse(jobid_str, &jobid) < 0) {
@@ -70,6 +73,7 @@ int internal_init(int verb)
 		goto out;
 	}
 
+	debug("flux parsed jobid_str successfully.\n");
 	jobid_valid = 1;
 
 out:
@@ -104,6 +108,8 @@ int internal_get_rem_time(time_t now, time_t last_update, int cached)
 	if ((flux_job_timeleft (h, &error, &timeleft)) == -1) {
 		error("ERROR: flux_job_timeleft() failed with error %s\n", error.text);
 		goto out;
+	} else {
+		debug("flux_job_timeleft returned %f.\n", timeleft);
 	}
 
 	if (timeleft > INT_MAX)


### PR DESCRIPTION
Adapt to two recent flux changes:

flux-core 0.47 provides an explicit flux_job_timeleft() so we no longer
need to support this more complex method for getting the information,
and there is better assurance the interface won't change.

Starting with flux-core v0.46, environment variable FLUX_JOB_ID is
not set for processes running in an allocation, but not launched by
flux, for example

```
$ mini alloc -n1 -t3
$ set | grep FLUX
```

See
* 485743d19 broker: clear job environment vars in rc scripts