### PR TITLE
slurm: include slurm.h in config test

### DIFF
--- a/config/x_ac_slurm.m4
+++ b/config/x_ac_slurm.m4
@@ -50,7 +50,7 @@ AC_DEFUN([X_AC_SLURM], [
             _x_ac_slurm_libs_save="$LIBS"
             LIBS="-L$d/$bit -lslurm -lpthread -lcrypto $LIBS"
             AC_LINK_IFELSE(
-              [AC_LANG_PROGRAM([],[slurm_get_rem_time(0);])],
+              [AC_LANG_PROGRAM([#include <slurm/slurm.h>],[slurm_get_rem_time(0);])],
               [AS_VAR_SET([x_ac_cv_slurm_dir], [$d])
                AS_VAR_SET([x_ac_cv_slurm_libdir], [$d/$bit])]
             )


### PR DESCRIPTION
@morrone , there is a reported problem building libyogrt with icx 2023.

https://github.com/spack/spack/issues/39462#issuecomment-1684299069

I haven't found this version of the compiler on our system, so I can't reproduce this yet.  I think we may just need to include the ``slurm.h`` header in the config test.  I'd like to be able to reproduce this before we merge, but I wanted to run this by you, as well.

