### PR TITLE
need to slurm_init(NULL) before calling slurm_get_rem_time(jobid)

### DIFF
--- a/src/slurm/internal.c
+++ b/src/slurm/internal.c
@@ -68,6 +68,7 @@ int internal_get_rem_time(time_t now, time_t last_update, int cached)
 	if (jobid == NO_VAL)
 		return -1;
 
+    slurm_init(NULL);
 	rem = (int)slurm_get_rem_time(jobid);
 	debug2("SLURM reports remaining time of %d sec.\n", rem);
 	return rem;


### PR DESCRIPTION
As of Slurm 23.02, you need to call slurm_init(NULL) before calling other slurm functions (e.g. slurm_get_rem_time) to avoid seg faults. See also https://lc.llnl.gov/jira/browse/TOSS-6192.