### PR TITLE
call slurm_init() before other slurm_*() calls

### DIFF
--- a/src/slurm/internal.c
+++ b/src/slurm/internal.c
@@ -38,6 +38,7 @@ int internal_init(int verb)
 
         if (getenv("SLURM_JOB_ID") != NULL
             || getenv("SLURM_JOBID") != NULL) {
+                slurm_init(NULL);
                 return 1;
         } else {
                 debug("ERROR: Neither SLURM_JOBID nor SLURM_JOB_ID are set."


### PR DESCRIPTION
slurm now makes it a requirement to call slurm_init() before any other slurm_*() calls.